### PR TITLE
Improved phpBB Link Capability

### DIFF
--- a/forum-plugins/plugin_phpbb3/readme.md
+++ b/forum-plugins/plugin_phpbb3/readme.md
@@ -2,22 +2,21 @@ PHPBB3
 =================
 
 You don't need to install everything. With the following bbcode custom config you can do it yourself.
-The usage is a bit different than the usage of the other plugins but it works too.
 
 Config:
 --------
 
 BB-Code:
 
-    [smurfy]{INTTEXT1}&L={INTTEXT2}[/smurfy]
+    [smurfy]http://mwo.smurfy-net.de/mechlab#i={SIMPLETEXT1}&l={SIMPLETEXT2}[/smurfy]
 
 HTML-Replacement:
 
-    <iframe src="http://mwo.smurfy-net.de/tools/mechtooltip?i={INTTEXT1}&l={INTTEXT2}" width="100%" height="300" border="0"></iframe>
+    <iframe src="http://mwo.smurfy-net.de/tools/mechtooltip?i={SIMPLETEXT1}&l={SIMPLETEXT2}"width="100%" height="300" border="0"></iframe>
 Tooltip:
 
-    Insert the Code after "http://mwo.smurfy-net.de/mechlab#i="
+    Copy the entire sumurfy mech link.
 
 Usage:
 -------
-[smurfy]7&l=0c5baded02023e70daac9803845aae9718d48c15[/smurfy]
+[smurfy]http://mwo.smurfy-net.de/mechlab#i=17&l=351f8b1c193fe77a4e723872124f26a012f90ea2[/smurfy]

--- a/forum-plugins/plugin_phpbb3/readme.md
+++ b/forum-plugins/plugin_phpbb3/readme.md
@@ -15,7 +15,7 @@ HTML-Replacement:
     <iframe src="http://mwo.smurfy-net.de/tools/mechtooltip?i={SIMPLETEXT1}&l={SIMPLETEXT2}"width="100%" height="300" border="0"></iframe>
 Tooltip:
 
-    Copy the entire sumurfy mech link.
+    Copy the entire smurfy mech link.
 
 Usage:
 -------


### PR DESCRIPTION
I improved the [smurfy] tag implementation via the PhpBB bbCode addition tool.  It turns out that the text replacements are actually a powerful regular expression generator/tokenizer, so you can use the full URL, just like all of the other [smurfy] code implementations.

Much easier for users to use.
